### PR TITLE
Raw certs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,16 @@ repository = "https://github.com/ctz/rustls-native-certs"
 categories = ["network-programming", "cryptography"]
 
 [dependencies]
-rustls = "0.18.0"
+rustls = { version = "0.18.0", optional = true }
 
 [dev-dependencies]
 webpki = "0.21"
 webpki-roots = "0"
 ring = "0.16.5"
 untrusted = "0.7.0"
+
+[features]
+default = ["rustls"]
 
 [target.'cfg(windows)'.dependencies]
 schannel = "0.1.15"

--- a/admin/pipelines/cargo-steps.yml
+++ b/admin/pipelines/cargo-steps.yml
@@ -1,6 +1,8 @@
 steps:
   - script: cargo build
     displayName: "cargo build (debug; default features)"
+  - script: cargo build --no-default-features
+    displayName: "cargo build (debug; no default features)"
   - script: cargo test
     displayName: "cargo test (debug; default features)"
     env: { "RUST_BACKTRACE": "1" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,13 @@ mod macos;
 use macos as platform;
 
 use rustls::RootCertStore;
-use std::io::Error;
+use std::io::{Error, ErrorKind};
+use std::io::BufRead;
+
+pub trait RootStoreBuilder {
+    fn load_der(&mut self, der: Vec<u8>) -> Result<(), Error>;
+    fn load_pem_file(&mut self, rd: &mut dyn BufRead) -> Result<(), Error>;
+}
 
 /// Loads root certificates found in the platform's native certificate
 /// store.
@@ -37,5 +43,38 @@ use std::io::Error;
 /// and parsing a ~300KB disk file.  It's therefore prudent to call
 /// this sparingly.
 pub fn load_native_certs() -> PartialResult<RootCertStore, Error> {
-    platform::load_native_certs()
+    struct RootCertStoreLoader {
+        store: RootCertStore,
+    };
+    impl RootStoreBuilder for RootCertStoreLoader {
+        fn load_der(&mut self, der: Vec<u8>) -> Result<(), Error> {
+            self.store.add(&rustls::Certificate(der))
+                .map_err(|err| Error::new(ErrorKind::InvalidData, err))
+        }
+        fn load_pem_file(&mut self, rd: &mut dyn BufRead) -> Result<(), Error> {
+            self.store.add_pem_file(rd)
+                .map(|_| ())
+                .map_err(|()| Error::new(ErrorKind::InvalidData, format!("could not load PEM file")))
+        }
+    }
+    let mut loader = RootCertStoreLoader {
+        store: RootCertStore::empty(),
+    };
+    match build_native_certs(&mut loader) {
+        Err(err) if loader.store.is_empty() => Err((None, err)),
+        Err(err) => Err((Some(loader.store), err)),
+        Ok(()) => Ok(loader.store),
+    }
+}
+
+/// Loads root certificates found in the platform's native certificate
+/// store, executing callbacks on the provided builder.
+///
+/// This function fails in a platform-specific way, expressed in a `std::io::Error`.
+///
+/// This function can be expensive: on some platforms it involves loading
+/// and parsing a ~300KB disk file.  It's therefore prudent to call
+/// this sparingly.
+pub fn build_native_certs<B: RootStoreBuilder>(builder: &mut B) -> Result<(), Error> {
+    platform::build_native_certs(builder)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,4 +23,19 @@ mod macos;
 #[cfg(target_os = "macos")]
 use macos as platform;
 
-pub use platform::load_native_certs;
+use rustls::RootCertStore;
+use std::io::Error;
+
+/// Loads root certificates found in the platform's native certificate
+/// store.
+///
+/// On success, this returns a `rustls::RootCertStore` loaded with a
+/// snapshop of the root certificates found on this platform.  This
+/// function fails in a platform-specific way, expressed in a `std::io::Error`.
+///
+/// This function can be expensive: on some platforms it involves loading
+/// and parsing a ~300KB disk file.  It's therefore prudent to call
+/// this sparingly.
+pub fn load_native_certs() -> PartialResult<RootCertStore, Error> {
+    platform::load_native_certs()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,14 @@
 //! rustls-native-certs allows rustls to use the platform's native certificate
 //! store when operating as a TLS client.
 //!
-//! It consists of a single function [load_native_certs](fn.load_native_certs.html) which returns a
-//! `rustls::RootCertStore` pre-filled from the native certificate store.
-
-/// Like `Result<T,E>`, but allows for functions that can return partially complete
-/// work alongside an error.
-pub type PartialResult<T, E> = Result<T, (Option<T>, E)>;
+//! It provides the following functions:
+//! * A higher level function [load_native_certs](fn.build_native_certs.html)
+//!   which returns a `rustls::RootCertStore` pre-filled from the native
+//!   certificate store. It is only available if the `rustls` feature is
+//!   enabled.
+//! * A lower level function [build_native_certs](fn.build_native_certs.html)
+//!   that lets callers pass their own certificate parsing logic. It is
+//!   available to all users.
 
 #[cfg(all(unix, not(target_os = "macos")))]
 mod unix;
@@ -23,48 +25,18 @@ mod macos;
 #[cfg(target_os = "macos")]
 use macos as platform;
 
-use rustls::RootCertStore;
-use std::io::{Error, ErrorKind};
+#[cfg(feature = "rustls")]
+mod rustls;
+
+use std::io::Error;
 use std::io::BufRead;
+
+#[cfg(feature = "rustls")]
+pub use crate::rustls::{load_native_certs, PartialResult};
 
 pub trait RootStoreBuilder {
     fn load_der(&mut self, der: Vec<u8>) -> Result<(), Error>;
     fn load_pem_file(&mut self, rd: &mut dyn BufRead) -> Result<(), Error>;
-}
-
-/// Loads root certificates found in the platform's native certificate
-/// store.
-///
-/// On success, this returns a `rustls::RootCertStore` loaded with a
-/// snapshop of the root certificates found on this platform.  This
-/// function fails in a platform-specific way, expressed in a `std::io::Error`.
-///
-/// This function can be expensive: on some platforms it involves loading
-/// and parsing a ~300KB disk file.  It's therefore prudent to call
-/// this sparingly.
-pub fn load_native_certs() -> PartialResult<RootCertStore, Error> {
-    struct RootCertStoreLoader {
-        store: RootCertStore,
-    };
-    impl RootStoreBuilder for RootCertStoreLoader {
-        fn load_der(&mut self, der: Vec<u8>) -> Result<(), Error> {
-            self.store.add(&rustls::Certificate(der))
-                .map_err(|err| Error::new(ErrorKind::InvalidData, err))
-        }
-        fn load_pem_file(&mut self, rd: &mut dyn BufRead) -> Result<(), Error> {
-            self.store.add_pem_file(rd)
-                .map(|_| ())
-                .map_err(|()| Error::new(ErrorKind::InvalidData, format!("could not load PEM file")))
-        }
-    }
-    let mut loader = RootCertStoreLoader {
-        store: RootCertStore::empty(),
-    };
-    match build_native_certs(&mut loader) {
-        Err(err) if loader.store.is_empty() => Err((None, err)),
-        Err(err) => Err((Some(loader.store), err)),
-        Ok(()) => Ok(loader.store),
-    }
 }
 
 /// Loads root certificates found in the platform's native certificate

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -9,16 +9,6 @@ use std::collections::HashMap;
 
 use crate::PartialResult;
 
-/// Loads root certificates found in the platform's native certificate
-/// store.
-///
-/// On success, this returns a `rustls::RootCertStore` loaded with a
-/// snapshop of the root certificates found on this platform.  This
-/// function fails in a platform-specific way, expressed in a `std::io::Error`.
-///
-/// This function can be expensive: on some platforms it involves loading
-/// and parsing a ~300KB disk file.  It's therefore prudent to call
-/// this sparingly.
 pub fn load_native_certs() -> PartialResult<RootCertStore, Error> {
     let mut store = RootCertStore::empty();
 

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -3,15 +3,12 @@ use security_framework::trust_settings::{
     TrustSettings,
     TrustSettingsForCertificate
 };
-use rustls::RootCertStore;
 use std::io::{Error, ErrorKind};
 use std::collections::HashMap;
 
-use crate::PartialResult;
+use crate::RootStoreBuilder;
 
-pub fn load_native_certs() -> PartialResult<RootCertStore, Error> {
-    let mut store = RootCertStore::empty();
-
+pub fn build_native_certs<B: RootStoreBuilder>(builder: &mut B) -> Result<(), Error> {
     // The various domains are designed to interact like this:
     //
     // "Per-user Trust Settings override locally administered
@@ -28,7 +25,7 @@ pub fn load_native_certs() -> PartialResult<RootCertStore, Error> {
     for domain in &[Domain::User, Domain::Admin, Domain::System] {
         let ts = TrustSettings::new(*domain);
         let iter = ts.iter()
-            .map_err(|err| (None, Error::new(ErrorKind::Other, err)))?;
+            .map_err(|err| Error::new(ErrorKind::Other, err))?;
 
         for cert in iter {
             let der = cert.to_der();
@@ -40,7 +37,7 @@ pub fn load_native_certs() -> PartialResult<RootCertStore, Error> {
             // "Note that an empty Trust Settings array means "always trust this cert,
             //  with a resulting kSecTrustSettingsResult of kSecTrustSettingsResultTrustRoot".
             let trusted = ts.tls_trust_settings_for_certificate(&cert)
-                .map_err(|err| (None, Error::new(ErrorKind::Other, err)))?
+                .map_err(|err| Error::new(ErrorKind::Other, err))?
                 .unwrap_or(TrustSettingsForCertificate::TrustRoot);
 
             all_certs.entry(der)
@@ -56,7 +53,7 @@ pub fn load_native_certs() -> PartialResult<RootCertStore, Error> {
         match trusted {
             TrustSettingsForCertificate::TrustRoot |
                 TrustSettingsForCertificate::TrustAsRoot => {
-                match store.add(&rustls::Certificate(der)) {
+                match builder.load_der(der) {
                     Err(err) => {
                         first_error = first_error
                             .or_else(|| Some(Error::new(ErrorKind::InvalidData, err)));
@@ -69,12 +66,8 @@ pub fn load_native_certs() -> PartialResult<RootCertStore, Error> {
     }
 
     if let Some(err) = first_error {
-        if store.is_empty() {
-            Err((None, err))
-        } else {
-            Err((Some(store), err))
-        }
+        Err(err)
     } else {
-        Ok(store)
+        Ok(())
     }
 }

--- a/src/rustls.rs
+++ b/src/rustls.rs
@@ -1,0 +1,47 @@
+use rustls::RootCertStore;
+use std::io::{Error, ErrorKind};
+use std::io::BufRead;
+use crate::RootStoreBuilder;
+
+/// Like `Result<T,E>`, but allows for functions that can return partially complete
+/// work alongside an error.
+///
+/// *This type is available only if the crate is built with the "rustls" feature.*
+pub type PartialResult<T, E> = Result<T, (Option<T>, E)>;
+
+/// Loads root certificates found in the platform's native certificate
+/// store.
+///
+/// On success, this returns a `rustls::RootCertStore` loaded with a
+/// snapshop of the root certificates found on this platform.  This
+/// function fails in a platform-specific way, expressed in a `std::io::Error`.
+///
+/// This function can be expensive: on some platforms it involves loading
+/// and parsing a ~300KB disk file.  It's therefore prudent to call
+/// this sparingly.
+///
+/// *This function is available only if the crate is built with the "rustls" feature.*
+pub fn load_native_certs() -> PartialResult<RootCertStore, Error> {
+    struct RootCertStoreLoader {
+        store: RootCertStore,
+    };
+    impl RootStoreBuilder for RootCertStoreLoader {
+        fn load_der(&mut self, der: Vec<u8>) -> Result<(), Error> {
+            self.store.add(&rustls::Certificate(der))
+                .map_err(|err| Error::new(ErrorKind::InvalidData, err))
+        }
+        fn load_pem_file(&mut self, rd: &mut dyn BufRead) -> Result<(), Error> {
+            self.store.add_pem_file(rd)
+                .map(|_| ())
+                .map_err(|()| Error::new(ErrorKind::InvalidData, format!("could not load PEM file")))
+        }
+    }
+    let mut loader = RootCertStoreLoader {
+        store: RootCertStore::empty(),
+    };
+    match crate::build_native_certs(&mut loader) {
+        Err(err) if loader.store.is_empty() => Err((None, err)),
+        Err(err) => Err((Some(loader.store), err)),
+        Ok(()) => Ok(loader.store),
+    }
+}

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,16 +1,14 @@
+use crate::RootStoreBuilder;
 use openssl_probe;
-use rustls::RootCertStore;
 use std::io::{Error, ErrorKind};
 use std::io::BufReader;
 use std::fs::File;
 use std::path::Path;
 
-use crate::PartialResult;
-
-fn load_file(store: &mut RootCertStore, path: &Path) -> Result<(), Error> {
+fn load_file(builder: &mut impl RootStoreBuilder, path: &Path) -> Result<(), Error> {
     let f = File::open(&path)?;
     let mut f = BufReader::new(f);
-    if store.add_pem_file(&mut f).is_err() {
+    if builder.load_pem_file(&mut f).is_err() {
         Err(Error::new(ErrorKind::InvalidData,
                        format!("Could not load PEM file {:?}", path)))
     } else {
@@ -18,13 +16,12 @@ fn load_file(store: &mut RootCertStore, path: &Path) -> Result<(), Error> {
     }
 }
 
-pub fn load_native_certs() -> PartialResult<RootCertStore, Error> {
+pub fn build_native_certs<B: RootStoreBuilder>(builder: &mut B) -> Result<(), Error> {
     let likely_locations = openssl_probe::probe();
-    let mut store = RootCertStore::empty();
     let mut first_error = None;
 
     if let Some(file) = likely_locations.cert_file {
-        match load_file(&mut store, &file) {
+        match load_file(builder, &file) {
             Err(err) => {
                 first_error = first_error.or_else(|| Some(err));
             }
@@ -33,12 +30,8 @@ pub fn load_native_certs() -> PartialResult<RootCertStore, Error> {
     }
 
     if let Some(err) = first_error {
-        if store.is_empty() {
-            Err((None, err))
-        } else {
-            Err((Some(store), err))
-        }
+        Err(err)
     } else {
-        Ok(store)
+        Ok(())
     }
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -18,17 +18,6 @@ fn load_file(store: &mut RootCertStore, path: &Path) -> Result<(), Error> {
     }
 }
 
-/// Loads root certificates found in the platform's native certificate
-/// store.
-///
-/// On success, this returns a `rustls::RootCertStore` loaded with a
-/// snapshop of the root certificates found on this platform.  This
-/// function fails in a platform-specific way, expressed in a `std::io::Error`.
-/// It may produce partial output.
-///
-/// This function can be expensive: on some platforms it involves loading
-/// and parsing a ~300KB disk file.  It's therefore prudent to call
-/// this sparingly.
 pub fn load_native_certs() -> PartialResult<RootCertStore, Error> {
     let likely_locations = openssl_probe::probe();
     let mut store = RootCertStore::empty();

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -15,16 +15,6 @@ fn usable_for_rustls(uses: schannel::cert_context::ValidUses) -> bool {
     }
 }
 
-/// Loads root certificates found in the platform's native certificate
-/// store.
-///
-/// On success, this returns a `rustls::RootCertStore` loaded with a
-/// snapshop of the root certificates found on this platform.  This
-/// function fails in a platform-specific way, expressed in a `std::io::Error`.
-///
-/// This function can be expensive: on some platforms it involves loading
-/// and parsing a ~300KB disk file.  It's therefore prudent to call
-/// this sparingly.
 pub fn load_native_certs() -> PartialResult<RootCertStore, Error> {
     let mut store = RootCertStore::empty();
     let mut first_error = None;


### PR DESCRIPTION
Adds a new function to let users parse the raw certificates, and turns the rustls dependency into an optional one, but enabled by default.

Fixes #2