### PR TITLE
Fix dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ categories = ["network-programming", "cryptography"]
 rustls = { version = "0.19.0", optional = true }
 
 [dev-dependencies]
-webpki = "0.21"
+webpki = "0.21.4"
 webpki-roots = "0.21.1"
-ring = "0.16.5"
+ring = "0.16.20"
 untrusted = "0.7.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rustls = { version = "0.19.0", optional = true }
 
 [dev-dependencies]
 webpki = "0.21"
-webpki-roots = "0"
+webpki-roots = "0.21.1"
 ring = "0.16.5"
 untrusted = "0.7.0"
 


### PR DESCRIPTION
Fix the webpki-roots dependency specification to limit it to 0.21.x, since 0.22.x and later versions aren't API compatible.

Update the dependency specification for *ring* (and webpki) to the versions that work on ARM Macs.