### PR TITLE
Use rustls-pemfile instead of old Rustls internal pemfile API.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ categories = ["network-programming", "cryptography"]
 rustls = { version = "0.19.0", optional = true }
 
 [dev-dependencies]
-webpki = "0.21"
+webpki = "0.21.4"
 webpki-roots = "0.21.1"
-ring = "0.16.5"
+ring = "0.16.20"
 untrusted = "0.7.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["network-programming", "cryptography"]
 
 [dependencies]
 rustls = { version = "0.19.0", optional = true }
+rustls-pemfile = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 webpki = "0.21.4"
@@ -20,7 +21,7 @@ ring = "0.16.20"
 untrusted = "0.7.0"
 
 [features]
-default = ["rustls"]
+default = ["rustls", "rustls-pemfile"]
 
 [target.'cfg(windows)'.dependencies]
 schannel = "0.1.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rustls = { version = "0.19.0", optional = true }
 
 [dev-dependencies]
 webpki = "0.21"
-webpki-roots = "0"
+webpki-roots = "0.21.1"
 ring = "0.16.5"
 untrusted = "0.7.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,8 @@
 //! It provides the following functions:
 //! * A higher level function [load_native_certs](fn.build_native_certs.html)
 //!   which returns a `rustls::RootCertStore` pre-filled from the native
-//!   certificate store. It is only available if the `rustls` feature is
-//!   enabled.
+//!   certificate store. It is only available if the `rustls` and `rustls-pemfile`
+//!   features are enabled.
 //! * A lower level function [build_native_certs](fn.build_native_certs.html)
 //!   that lets callers pass their own certificate parsing logic. It is
 //!   available to all users.
@@ -25,7 +25,7 @@ mod macos;
 #[cfg(target_os = "macos")]
 use macos as platform;
 
-#[cfg(feature = "rustls")]
+#[cfg(all(feature = "rustls", feature = "rustls-pemfile"))]
 mod rustls;
 
 use std::io::Error;


### PR DESCRIPTION
Take a step towards supporting the upcoming version of Rustls.