### PR TITLE
Update to security-framework 2.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,4 @@ schannel = "0.1.15"
 openssl-probe = "0.1.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-security-framework = "2.0.0"
+security-framework = "2.2.0"

--- a/src/rustls.rs
+++ b/src/rustls.rs
@@ -24,7 +24,7 @@ pub type PartialResult<T, E> = Result<T, (Option<T>, E)>;
 pub fn load_native_certs() -> PartialResult<RootCertStore, Error> {
     struct RootCertStoreLoader {
         store: RootCertStore,
-    };
+    }
     impl RootStoreBuilder for RootCertStoreLoader {
         fn load_der(&mut self, der: Vec<u8>) -> Result<(), Error> {
             self.store.add(&rustls::Certificate(der))


### PR DESCRIPTION
Update a core-foundation dependency via the latest version of security
framework.

Signed-off-by: Sean Pianka <pianka@eml.cc>